### PR TITLE
fix: maintain consistent user IDs across pages

### DIFF
--- a/pages/result/index.tsx
+++ b/pages/result/index.tsx
@@ -166,7 +166,9 @@ const ResultPage: NextPage<ResultPageProps> = ({
         answer: userAnswer,
         feedback: feedbackData,
         timestamp: Date.now(),
-        answerLanguage: isJapanese ? 'ja' : 'en' // 回答時の言語設定を保存
+        answerLanguage: isJapanese ? 'ja' : 'en', // 回答時の言語設定を保存
+        quizUserId: quizUser.id, // クイズユーザーIDを保存
+        replyUserId: replyUser.id // リプライユーザーIDを保存
       };
       
       try {

--- a/pages/share/[id].tsx
+++ b/pages/share/[id].tsx
@@ -93,9 +93,11 @@ const SharePage: NextPage<SharePageProps> = ({
     setPageTitle(`${t.appTitle} - ${t.sharedResultView} (${score}/100)`);
   }, [t, score]);
   
-  // ユーザー情報の初期化 (固定のシード値を使用)
+  // ユーザー情報の初期化 (固定のシード値とシェアデータ内のユーザーIDを使用)
   const seedBase = `share-${shareId}`;
-  const initialUsers = initializeUsers(seedBase, quizId, isJapanese);
+  const savedQuizUserId = resultData.quizUserId;
+  const savedReplyUserId = resultData.replyUserId;
+  const initialUsers = initializeUsers(seedBase, quizId, isJapanese, savedQuizUserId, savedReplyUserId);
   const [quizUser, setQuizUser] = useState(initialUsers[0]);
   const [replyUser, setReplyUser] = useState(initialUsers[1]);
   const [currentGrokUser, setCurrentGrokUser] = useState(getGrokUser(isJapanese));
@@ -103,12 +105,12 @@ const SharePage: NextPage<SharePageProps> = ({
 
   // 言語が変更されたときにユーザー名を更新
   useEffect(() => {
-    // 言語に合わせてユーザー情報を更新
-    const updatedUsers = initializeUsers(seedBase, quizId, isJapanese);
+    // 言語に合わせてユーザー情報を更新（保存されたユーザーIDを使用）
+    const updatedUsers = initializeUsers(seedBase, quizId, isJapanese, savedQuizUserId, savedReplyUserId);
     setQuizUser(updatedUsers[0]);
     setReplyUser(updatedUsers[1]);
     setCurrentGrokUser(getGrokUser(isJapanese));
-  }, [isJapanese, seedBase, quizId]);
+  }, [isJapanese, seedBase, quizId, savedQuizUserId, savedReplyUserId]);
   
   // Xでシェアする
   const handleShare = () => {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -44,6 +44,8 @@ export interface ResultPageData {
   feedback: FeedbackData;
   timestamp: number;
   answerLanguage?: 'ja' | 'en'; // 回答時の言語設定
+  quizUserId?: number; // クイズを投稿したユーザーID
+  replyUserId?: number; // リプライを要求したユーザーID
 }
 
 // 結果ページのURLパラメータ


### PR DESCRIPTION
## Summary
- Add user IDs preservation between pages to ensure consistent user display
- Store user IDs in the shared result data
- Use preserved user IDs in share page to display the same users as in the result page

## Test plan
1. Answer a question on the home page
2. Verify the same users appear on the result page
3. Share the result and verify the same users appear on the share page